### PR TITLE
Allow bundle buying code to be configurable

### DIFF
--- a/custom_components/odido/__init__.py
+++ b/custom_components/odido/__init__.py
@@ -63,6 +63,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> True:
                 )
                 _LOGGER.debug(response)
 
+                return
+
         _LOGGER.error("No valid odido sensor found for device_id %s", device_id)
 
     hass.services.async_register("odido", "buy_bundle", handle_buy_bundle)

--- a/custom_components/odido/__init__.py
+++ b/custom_components/odido/__init__.py
@@ -40,22 +40,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> True:
 
     async def handle_buy_bundle(call):
         device_id = call.data["device_id"]
+        buying_code = call.data.get("buying_code")
 
         entity_registry = async_get_entity_registry(hass)
         entries = async_entries_for_device(entity_registry, device_id)
 
         for entry in entries:
             if (
-                    entry.domain == "sensor"
-                    and entry.platform == DOMAIN
-                    and entry.original_name == "Phone Number"
+                entry.domain == "sensor"
+                and entry.platform == DOMAIN
+                and entry.original_name == "Phone Number"
             ):
                 _LOGGER.debug(entry)
                 odido_api = hass.data[DOMAIN][entry.config_entry_id]["odido_api"]
 
                 state = hass.states.get(entry.entity_id)
 
-                response = await hass.async_add_executor_job(odido_api.buy_bundle, state.attributes.get('subscription_url'))
+                response = await hass.async_add_executor_job(
+                    odido_api.buy_bundle,
+                    state.attributes.get("subscription_url"),
+                    buying_code,
+                )
                 _LOGGER.debug(response)
 
         _LOGGER.error("No valid odido sensor found for device_id %s", device_id)

--- a/custom_components/odido/__init__.py
+++ b/custom_components/odido/__init__.py
@@ -4,7 +4,7 @@ import urllib3
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import (ConfigEntryNotReady, ConfigEntryAuthFailed)
+from homeassistant.exceptions import (ConfigEntryNotReady, ConfigEntryAuthFailed, HomeAssistantError)
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry, async_entries_for_device
 
@@ -63,7 +63,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> True:
                 )
                 _LOGGER.debug(response)
 
-                return
+                if "ErrorCode" in response:
+                    raise BuyingRoamingBundleError(response.get("ErrorCode"))
+
+                return True
 
         _LOGGER.error("No valid odido sensor found for device_id %s", device_id)
 
@@ -82,3 +85,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+class BuyingRoamingBundleError(HomeAssistantError):
+    """Error raised when an error occurred while buying a roaming bundle."""

--- a/custom_components/odido/const.py
+++ b/custom_components/odido/const.py
@@ -3,8 +3,11 @@ from homeassistant.const import Platform
 DOMAIN = "odido"
 
 PLATFORMS = [
-    Platform.SENSOR
+    Platform.SENSOR,
 ]
 
 ENCRYPTION_KEY = b"afIqRZm6iSev4zWysNGAjR6fCrOMf5GQqhKFfmXkgOU="
 OAUTH_KEY = b"9havvat6hm0b962i"
+
+DEFAULT_BUYING_CODE = "A0DAY01"
+

--- a/custom_components/odido/device_action.py
+++ b/custom_components/odido/device_action.py
@@ -1,10 +1,10 @@
 # custom_components/odido/device_action.py
 
-from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.helpers.device_registry import DeviceRegistry
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.helpers.entity_registry import async_entries_for_device
+import voluptuous as vol
 
-from .const import DOMAIN
+from .const import DOMAIN, DEFAULT_BUYING_CODE
 
 ACTION_TYPE_BUY_BUNDLE = "buy_bundle"
 
@@ -29,15 +29,34 @@ async def async_get_actions(hass, device_id):
 
 async def async_call_action_from_config(hass, config, variables, context=None):
     """Execute the action."""
-    entity_id = config[ATTR_ENTITY_ID]
+    entity_id = config.get(ATTR_ENTITY_ID)
+    device_id = config[ATTR_DEVICE_ID]
+
+    data = {ATTR_DEVICE_ID: device_id}
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+    if "buying_code" in config:
+        data["buying_code"] = config["buying_code"]
 
     await hass.services.async_call(
         DOMAIN,
         ACTION_TYPE_BUY_BUNDLE,
-        {ATTR_ENTITY_ID: entity_id},
+        data,
         context=context,
     )
+
+
+async def async_get_action_capabilities(hass, config):
+    """List capabilities of the action."""
+    return {
+        "extra_fields": vol.Schema(
+            {
+                vol.Optional("buying_code", default=DEFAULT_BUYING_CODE): vol.Coerce(str)
+            }
+        )
+    }
 
 def async_validate_action_config(hass, config):
     """Validate config if needed (basic passthrough here)."""
     return config
+

--- a/custom_components/odido/services.yaml
+++ b/custom_components/odido/services.yaml
@@ -10,3 +10,11 @@ buy_bundle:
         device:
           integration: odido
           domain: odido
+    buying_code:
+      name: Buying Code
+      description: Buying code for the bundle. Defaults to A0DAY01.
+      required: false
+      default: A0DAY01
+      selector:
+        text:
+


### PR DESCRIPTION
## Summary
- add DEFAULT_BUYING_CODE constant and allow overriding
- add optional buying_code to buy_bundle service and device action

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894953b048c8330ab33d98e413716c6